### PR TITLE
[feature/helpers-0] Added pr branch policy

### DIFF
--- a/.github/workflows/pr-branch-policy.yml
+++ b/.github/workflows/pr-branch-policy.yml
@@ -1,0 +1,74 @@
+name: PR Branch Policy
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches: [ dev, main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate branch, base, and title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Validate PR metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_REF="${{ github.base_ref }}"
+          HEAD_REF="${{ github.head_ref }}"
+          TITLE="${{ github.event.pull_request.title }}"
+
+          echo "Base: $BASE_REF"
+          echo "Head: $HEAD_REF"
+          echo "Title: $TITLE"
+
+          # Special case: allow dev -> main for releases
+          if [[ "$HEAD_REF" == "dev" && "$BASE_REF" == "main" ]]; then
+            echo "✅ Release PR: dev -> main allowed"
+            echo "PR checks passed."
+            exit 0
+          fi
+
+          # Special case: allow branches starting with [release] to target main
+          if [[ "$BASE_REF" == "main" && "$TITLE" =~ ^\[release\] ]]; then
+            echo "✅ Release PR to main: title starts with [release]"
+            echo "PR checks passed."
+            exit 0
+          fi
+
+          # Special case: allow Dependabot PRs to target dev without title requirements
+          if [[ "$HEAD_REF" =~ ^dependabot/ && "$BASE_REF" == "dev" ]]; then
+            echo "✅ Dependabot PR: $HEAD_REF -> dev allowed"
+            echo "PR checks passed."
+            exit 0
+          fi
+
+          # Allow both manual branches and Copilot-generated branches
+          branch_regex='^((helpers|git_helper|dependabot|dependancy|other|all)-[0-9]+|copilot/.*)$'
+
+          if [[ "$BASE_REF" != "dev" ]]; then
+            echo "::error::Pull requests must target 'dev' branch (found '$BASE_REF')." >&2
+            exit 1
+          fi
+
+          if [[ ! "$HEAD_REF" =~ $branch_regex ]]; then
+            echo "::error::Head branch '$HEAD_REF' does not match required pattern: $branch_regex" >&2
+            exit 1
+          fi
+
+          required_prefix="[$HEAD_REF] "
+          if [[ "$TITLE" != "$required_prefix"* ]]; then
+            echo "::error::PR title must start with '[${HEAD_REF}] '." >&2
+            echo "Suggested: [${HEAD_REF}] Concise description" >&2
+            exit 1
+          fi
+
+          echo "PR checks passed."


### PR DESCRIPTION
## Summary by Sourcery

Enforce pull request branch and title conventions via CI while tightening git-helper rebase behavior to consistently use remote tracking branches.

Enhancements:
- Update git-helper rebase commands to rebase onto remote tracking refs (origin/*) and ensure the current branch is fetched and pulled before history rebases.
- Improve user-facing rebase status messages to clearly reference the remote branch being used.

CI:
- Introduce a PR branch policy GitHub Actions workflow that validates base branch, head branch naming, and title format, with special cases for releases and Dependabot.