### PR TITLE
[feature/git_helper-13] Update script version to 1.0.1

### DIFF
--- a/git_helpers/git-helper.sh
+++ b/git_helpers/git-helper.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # If neither is available, fall back to a text-based menu.
 
 # Version information
-SCRIPT_VERSION="0.0.1"
+SCRIPT_VERSION="1.0.1"
 GITHUB_REPO="kumpeapps/helper_scripts"
 
 # Resolve the on-disk path to this script (without relying on realpath availability)


### PR DESCRIPTION
## Summary by Sourcery

Bump the git-helper script's internal version identifier to 1.0.1 to reflect the latest release of the helper utility.